### PR TITLE
Add CODEOWNERS and pull request template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# CODEOWNERS
+# Purpose: auto-request reviewers for changes.
+# Even as a solo project, this demonstrates review routing and can be used
+# with a second account to satisfy "approval required" branch protection.
+
+/docs/ @VivekNagra @Grumpz555
+/.devcontainer/ @VivekNagra @Grumpz555
+/src/ @VivekNagra @Grumpz555
+/tests/ @VivekNagra @Grumpz555
+
+
+* @VivekNagra @Grumpz555

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+Explain what this PR changes and why.
+
+## Linked issue
+Fixes #
+
+## Type of change
+- [ ] Feature
+- [ ] Bug fix
+- [ ] Documentation
+- [ ] Chore / tooling
+- [ ] Automation / CI
+
+## Checklist
+- [ ] My commits are clear and imperative (e.g., “Add…”, “Fix…”)
+- [ ] This PR is small and focused (not multiple unrelated changes)
+- [ ] I linked the relevant Issue (Fixes #…)
+- [ ] I added/updated documentation if needed
+- [ ] I ran tests locally (if applicable)
+
+## Notes for reviewer
+Anything specific you want the reviewer to focus on.


### PR DESCRIPTION
Fixes #5 
Fixes #9 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces basic GitHub repository hygiene for reviews and PRs.
> 
> - Adds `.github/CODEOWNERS` to auto-request reviewers for `docs/`, `.devcontainer/`, `src/`, and `tests/`, with a global default of `@VivekNagra @Grumpz555`
> - Adds `.github/pull_request_template.md` with sections for `Summary`, `Linked issue`, `Type of change`, a checklist, and `Notes for reviewer`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0aa0a5be44e29df08c21d5cef9bf989f6a7bef4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->