### PR TITLE
Add PR labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,28 @@
+"type:docs":
+  - any:
+      - "docs/**"
+      - "**/*.md"
+
+"area:docs":
+  - any:
+      - "docs/**"
+
+"type:automation":
+  - any:
+      - ".github/**"
+
+"area:github":
+  - any:
+      - ".github/**"
+
+"area:devcontainer":
+  - any:
+      - ".devcontainer/**"
+
+"area:api":
+  - any:
+      - "src/**"
+
+"area:tests":
+  - any:
+      - "tests/**"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,19 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply labels based on changed files
+        uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: true


### PR DESCRIPTION
## Summary
Explain what this PR changes and why.

## Linked issue
Fixes #7 

## Type of change
Automation / CI: automation of label association based on changed folders. 



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Automates PR labeling based on file path patterns to streamline triage.
> 
> - Adds `/.github/workflows/labeler.yml` using `actions/labeler@v5` on PR events with minimal permissions and `sync-labels: true`
> - Introduces `/.github/labeler.yml` mapping paths to labels: `type:docs`, `area:docs`, `type:automation`, `area:github`, `area:devcontainer`, `area:api`, `area:tests`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b603a724fa9202e885ee6fe9c0b27e5fa7bdec42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->