### PR TITLE
Fix labeler config to v5 format

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,28 +1,35 @@
 "type:docs":
-  - any:
-      - "docs/**"
-      - "**/*.md"
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "**/*.md"
 
 "area:docs":
-  - any:
-      - "docs/**"
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
 
 "type:automation":
-  - any:
-      - ".github/**"
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
 
 "area:github":
-  - any:
-      - ".github/**"
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
 
 "area:devcontainer":
-  - any:
-      - ".devcontainer/**"
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".devcontainer/**"
 
 "area:api":
-  - any:
-      - "src/**"
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/**"
 
 "area:tests":
-  - any:
-      - "tests/**"
+  - changed-files:
+      - any-glob-to-any-file:
+          - "tests/**"


### PR DESCRIPTION
## Summary
Explain what this PR changes and why.

## Linked issue
Fixes #7 #13 

## Type of change
- [ ] Feature
- [x] Bug fix
- [ ] Documentation
- [ ] Chore / tooling
- [ ] Automation / CI

## Checklist
- [ ] My commits are clear and imperative (e.g., “Add…”, “Fix…”)
- [ ] This PR is small and focused (not multiple unrelated changes)
- [ ] I linked the relevant Issue (Fixes #…)
- [ ] I added/updated documentation if needed
- [ ] I ran tests locally (if applicable)

## Notes for reviewer
Anything specific you want the reviewer to focus on.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the GitHub labeler configuration to v5, replacing legacy `any` matchers with `changed-files` → `any-glob-to-any-file`.
> 
> - Updates rules in `.github/labeler.yml` to apply labels for `docs/**`, `**/*.md`, `.github/**`, `.devcontainer/**`, `src/**`, and `tests/**` using the v5 schema
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6857868571c4bef7eec7e8cd0e3cb6880956b380. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->