### PR TITLE
Fix metrics workflow to use ISO merge date filter

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -22,8 +22,9 @@ jobs:
           echo "Time window: last 7 days"
           echo ""
 
-          echo "Merged PRs (last 7 days):"
-          gh pr list --state merged --search "merged:>=-7d" --json number,title,mergedAt --jq '.[] | "- #\(.number) \(.title) (merged: \(.mergedAt))"'
+          SINCE_DATE=$(date -u -d "7 days ago" +%F)
+          echo "Merged PRs since ${SINCE_DATE}:"
+          gh pr list --state merged --search "merged:>=${SINCE_DATE}" --json number,title,mergedAt --jq '.[] | "- #\(.number) \(.title) (merged: \(.mergedAt))"'
 
           echo ""
           echo "Open PRs:"


### PR DESCRIPTION
## Summary
Explain what this PR changes and why.

## Linked issue
Fixes #

## Type of change
- [ ] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Chore / tooling
- [ ] Automation / CI

## Checklist
- [ ] My commits are clear and imperative (e.g., “Add…”, “Fix…”)
- [ ] This PR is small and focused (not multiple unrelated changes)
- [ ] I linked the relevant Issue (Fixes #…)
- [ ] I added/updated documentation if needed
- [ ] I ran tests locally (if applicable)

## Notes for reviewer
Anything specific you want the reviewer to focus on.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the metrics workflow to use an ISO-formatted cutoff date for merged PR queries.
> 
> - Compute `SINCE_DATE` via `date -u -d "7 days ago" +%F` and use it in `gh pr list --search "merged:>=${SINCE_DATE}"`
> - Adjust output header to "Merged PRs since ${SINCE_DATE}"; open PR listing remains the same
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2075f193226a25e5389b178ca5e98fe8e0a00acc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->