### PR TITLE
Fix metrics workflow to run gh against explicit repo

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -14,6 +14,9 @@ jobs:
   summary:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout (for gh repo context)
+        uses: actions/checkout@v4
+
       - name: Summarize PR throughput (last 7 days)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -24,8 +27,19 @@ jobs:
 
           SINCE_DATE=$(date -u -d "7 days ago" +%F)
           echo "Merged PRs since ${SINCE_DATE}:"
-          gh pr list --state merged --search "merged:>=${SINCE_DATE}" --json number,title,mergedAt --jq '.[] | "- #\(.number) \(.title) (merged: \(.mergedAt))"'
+
+          gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state merged \
+            --search "merged:>=${SINCE_DATE}" \
+            --json number,title,mergedAt \
+            --jq '.[] | "- #\(.number) \(.title) (merged: \(.mergedAt))"'
 
           echo ""
           echo "Open PRs:"
-          gh pr list --state open --json number,title,createdAt --jq '.[] | "- #\(.number) \(.title) (opened: \(.createdAt))"'
+
+          gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state open \
+            --json number,title,createdAt \
+            --jq '.[] | "- #\(.number) \(.title) (opened: \(.createdAt))"'


### PR DESCRIPTION
## Summary
Explain what this PR changes and why.

## Linked issue
Fixes #

## Type of change
- [ ] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Chore / tooling
- [ ] Automation / CI

## Checklist
- [ ] My commits are clear and imperative (e.g., “Add…”, “Fix…”)
- [ ] This PR is small and focused (not multiple unrelated changes)
- [ ] I linked the relevant Issue (Fixes #…)
- [ ] I added/updated documentation if needed
- [ ] I ran tests locally (if applicable)

## Notes for reviewer
Anything specific you want the reviewer to focus on.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the metrics workflow queries the correct repository.
> 
> - Adds checkout step in `Metrics Summary` workflow to provide repo context
> - Updates both `gh pr list` invocations to include `--repo "$GITHUB_REPOSITORY"` for merged and open PR listings
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5267ce3af15b0f52cd5b66fdda1dc7307c422de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->